### PR TITLE
Set project maturity to Incubator

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: col-sidebar
 title: OWASP AI Maturity Assessment
 tags: AIMA
-level: 4
+level: 2
 type: documentation
 pitch: OWASP AI Maturity Assessment
 ---


### PR DESCRIPTION
Hi! You are using a wrong maturity level for your project. This makes it appear as Flagship-level in some places, such as OWASP Nest. Please accept this PR or change the level yourself to `2` which is your current maturity level. Available levels:

* `4` = Flagship
* `3.5` = Production
* `3` = Lab
* `2` = Incubator

Thank you!
@bkimminich (for the OWASP Project Committee)